### PR TITLE
feat(DimmableContainer): no longer nest model tab - #35

### DIFF
--- a/src/TemplateStudio/DimmableContainer/index.js
+++ b/src/TemplateStudio/DimmableContainer/index.js
@@ -189,27 +189,11 @@ class DimmableContainer extends React.Component {
     );
     const modelTabs = () => (
       <div>
-        <Menu attached="top" tabular>
-          <Menu.Item
-            name="model"
-            active={this.state.activeModel === 'model'}
-            onClick={this.handleModelTabChange}
-          >Model</Menu.Item>
-          <Menu.Item
-            href="https://docs.accordproject.org/docs/accordproject-specification.html#model"
-            target="_blank"
-            position="right"
-          >
-            <Icon name="info" />
-          </Menu.Item>
-        </Menu>
         { this.state.activeModel === 'model' ?
-          <Tab.Pane>
-            <ModelForm
-              model={model}
-              handleModelChange={this.props.handleModelChange}
-            />
-          </Tab.Pane> : null }
+          <ModelForm
+            model={model}
+            handleModelChange={this.props.handleModelChange}
+          /> : null }
       </div>
     );
     const metaTabs = () => (

--- a/src/TemplateStudio/Utils.js
+++ b/src/TemplateStudio/Utils.js
@@ -22,7 +22,7 @@ import { ModelFile } from 'composer-concerto';
 
 /* Ergo */
 
-import Ergo from '@accordproject/ergo-compiler/lib/ergo.js';
+import Ergo from '@accordproject/ergo-compiler/lib/compiler.js';
 
 function getUrlVars() {
   const vars = {};

--- a/src/TemplateStudio/Utils.js
+++ b/src/TemplateStudio/Utils.js
@@ -22,7 +22,7 @@ import { ModelFile } from 'composer-concerto';
 
 /* Ergo */
 
-import Ergo from '@accordproject/ergo-compiler/lib/compiler.js';
+import Ergo from '@accordproject/ergo-compiler/lib/ergo.js';
 
 function getUrlVars() {
   const vars = {};


### PR DESCRIPTION
[Issue](https://github.com/accordproject/template-studio/issues/35)

There appears to be no need for the Menu and the two Menu.Items

**FLAGS**:
Ternary may be unnecessary because there are no Menu.Items for state.activeModel