### PR TITLE
chore(github) - add action to deploy to AWS S3

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -44,22 +44,13 @@ jobs:
         run: |
             echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
 
-      - name: Deploy 'src' to S3
+      - name: Deploy to S3
         if: github.ref == 'refs/heads/master'
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
-          SOURCE_DIR: 'src'
-
-      - name: Deploy 'static' to S3
-        if: github.ref == 'refs/heads/master'
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          SOURCE_DIR: 'static'
-          DEST_DIR: 'static'
+          SOURCE_DIR: 'dist'
 
       - name: Invalidate Cloudfront
         uses: chetan/invalidate-cloudfront-action@master

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -44,13 +44,22 @@ jobs:
         run: |
             echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
 
-      - name: Deploy to S3
+      - name: Deploy 'src' to S3
         if: github.ref == 'refs/heads/master'
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
           SOURCE_DIR: 'src'
+
+      - name: Deploy 'static' to S3
+        if: github.ref == 'refs/heads/master'
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          SOURCE_DIR: 'static'
+          DEST_DIR: 'static'
 
       - name: Invalidate Cloudfront
         uses: chetan/invalidate-cloudfront-action@master

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
-          SOURCE_DIR: 'website/build/techdocs'
+          SOURCE_DIR: 'build'
 
       - name: Invalidate Cloudfront
         uses: chetan/invalidate-cloudfront-action@master

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
-          SOURCE_DIR: 'build'
+          SOURCE_DIR: 'src'
 
       - name: Invalidate Cloudfront
         uses: chetan/invalidate-cloudfront-action@master

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,60 @@
+name: Build and Publish
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: NPM Install
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pwd
+          npm install
+
+      - name: NPM Build
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pwd
+          npm run build
+
+      - name: Set S3 
+        if: github.ref == 'refs/heads/master'
+        run: |
+            echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
+
+      - name: Deploy to S3
+        if: github.ref == 'refs/heads/master'
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          SOURCE_DIR: 'website/build/techdocs'
+
+      - name: Invalidate Cloudfront
+        uses: chetan/invalidate-cloudfront-action@master
+        env:
+          DISTRIBUTION: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+          PATHS: '/*'
+          AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
Creates an GitHub "Action" to build and deploy to AWS S3.

Requires the following "SECRETS" to be specified in GitHub.
```
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_S3_BUCKET
```
Will need to add the following secrets to the repo.

```
AWS_CLOUDFRONT_DISTRIBUTION_ID : E22V3CVHJHS92P
AWS_REGION : us-east-1
```

The invalidation is created after each deployment to S3 and can be seen here:
https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/E22V3CVHJHS92P/invalidations

The S3 Bucket URL for testing is:
http://studio.accordproject.org.s3-website-us-east-1.amazonaws.com/

The CloudFront Distro URL for testing is:
https://d31lzdnw1gfzn9.cloudfront.net/